### PR TITLE
Update README to indicate macOS 12 requirement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Tip: Right-click an item in the sidebar to copy the type identifier.
 
 [![](https://tools.applemediaservices.com/api/badges/download-on-the-mac-app-store/black/en-us?size=250x83&releaseDate=1615852800)](https://apps.apple.com/app/id1499215709)
 
-Requires macOS 11 or later.
+Requires macOS 12 or later.
 
 **Older versions**
 


### PR DESCRIPTION
Looks like you've updated this project to require macOS 12 per d135a36029a2afec91af3176536b07c113a03715, but didn't update one line of the README.

Thanks for including links to older versions for macOS 11 and 10!