### PR TITLE
Fix validates_start_with_lowercase in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -165,7 +165,7 @@ identifier_name:
   min_length:
     warning: 2
     error: 2
-  validates_start_with_lowercase: false
+  validates_start_with_lowercase: off
   allowed_symbols:
     - '_'
   excluded:


### PR DESCRIPTION
Use new syntax for disabling validates_start_with_lowercase