### PR TITLE
Remove sidebar maxWidth

### DIFF
--- a/Pasteboard Viewer/MainScreen.swift
+++ b/Pasteboard Viewer/MainScreen.swift
@@ -58,8 +58,8 @@ struct MainScreen: View {
 				sourceAppView
 			}
 			// TODO: Use this when SwiftUI is able to persist the sidebar size.
-			// .frame(minWidth: 180, idealWidth: 200, maxWidth: 300)
-			.frame(minWidth: 200, maxWidth: 300)
+			// .frame(minWidth: 180, idealWidth: 200)
+			.frame(minWidth: 200)
 			.toolbar {
 				ToolbarItem(placement: .primaryAction) {
 					EnumPicker("Pasteboard", selection: $selectedPasteboard) {


### PR DESCRIPTION
The maxWidth was applying only to the List it contained, so the sidebar wasn't prevented form being resized larger than maxWidth. When this happens, the List appears at it's maxWidth centred in the sidebar.

I did try setting it on the sidebar directly (when it's added to the NavigationView), but this had the same effect (the NavigationView could still be resized larger than maxWidth, with the same effect as before).