### PR TITLE
Allow clearing pasteboards

### DIFF
--- a/Pasteboard Viewer/App.swift
+++ b/Pasteboard Viewer/App.swift
@@ -23,6 +23,12 @@ struct AppMain: App {
 		}
 			.commands {
 				CommandGroup(replacing: .newItem) {}
+				CommandGroup(after: .pasteboard) {
+					Divider()
+					Button("Clear Pasteboard") {
+						// TODO: clear pasteboard
+					}
+				}
 				CommandGroup(after: .toolbar) {
 					Defaults.Toggle("Show \"Clear Pasteboard\" Button", key: .showClearPasteboardButton)
 					Divider()

--- a/Pasteboard Viewer/App.swift
+++ b/Pasteboard Viewer/App.swift
@@ -23,6 +23,10 @@ struct AppMain: App {
 		}
 			.commands {
 				CommandGroup(replacing: .newItem) {}
+				CommandGroup(after: .toolbar) {
+					Defaults.Toggle("Show \"Clear Pasteboard\" Button", key: .showClearPasteboardButton)
+					Divider()
+				}
 				CommandGroup(after: .windowSize) {
 					Defaults.Toggle("Stay on Top", key: .stayOnTop)
 						.keyboardShortcut("t", modifiers: [.control, .command])

--- a/Pasteboard Viewer/Constants.swift
+++ b/Pasteboard Viewer/Constants.swift
@@ -1,3 +1,4 @@
 extension Defaults.Keys {
+	static let showClearPasteboardButton = Key<Bool>("showClearPasteboardOnToolbar", default: false)
 	static let stayOnTop = Key<Bool>("stayInFront", default: false)
 }

--- a/Pasteboard Viewer/MainScreen.swift
+++ b/Pasteboard Viewer/MainScreen.swift
@@ -66,6 +66,13 @@ struct MainScreen: View {
 						Text($0.nsPasteboard.presentableName)
 					}
 				}
+				ToolbarItem(placement: .primaryAction) {
+					Button {
+						selectedPasteboard.nsPasteboard.clearContents()
+					} label: {
+						Label("Clear", systemImage: "trash")
+					}
+				}
 			}
 	}
 

--- a/Pasteboard Viewer/MainScreen.swift
+++ b/Pasteboard Viewer/MainScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainScreen: View {
 	@StateObject private var pasteboardObservable = NSPasteboard.Observable(.general)
+	@Default(.showClearPasteboardButton) private var showClearPasteboardButton
 	@Default(.stayOnTop) private var stayOnTop
 	@State private var selectedPasteboard = Pasteboard.general
 	@State private var selectedType: Pasteboard.Type_?
@@ -66,11 +67,13 @@ struct MainScreen: View {
 						Text($0.nsPasteboard.presentableName)
 					}
 				}
-				ToolbarItem(placement: .primaryAction) {
-					Button {
-						selectedPasteboard.nsPasteboard.clearContents()
-					} label: {
-						Label("Clear", systemImage: "trash")
+				if showClearPasteboardButton {
+					ToolbarItem(placement: .primaryAction) {
+						Button {
+							selectedPasteboard.nsPasteboard.clearContents()
+						} label: {
+							Label("Clear", systemImage: "trash")
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Adds a toolbar button to clear the selected pasteboard (and increases the sidebar `minWidth` to accomodate).

Fixes #17.