### PR TITLE
Hex viewer

### DIFF
--- a/Pasteboard Viewer.xcodeproj/project.pbxproj
+++ b/Pasteboard Viewer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		55FABE8A2BE1801E004E66FD /* HexFiend in Frameworks */ = {isa = PBXBuildFile; platformFilters = (macos, ); productRef = 55FABE892BE1801E004E66FD /* HexFiend */; };
 		E3065AA82B81118700475AB5 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = E3065AA72B81118700475AB5 /* Collections */; };
 		E31C294223FBE2FA00DF3442 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = E31C294123FBE2FA00DF3442 /* Defaults */; };
 		E31C294423FBE32200DF3442 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31C294323FBE32200DF3442 /* Constants.swift */; };
@@ -48,6 +49,7 @@
 				E3065AA82B81118700475AB5 /* Collections in Frameworks */,
 				E31C294223FBE2FA00DF3442 /* Defaults in Frameworks */,
 				E3494C16297D175B00983648 /* Introspect in Frameworks */,
+				55FABE8A2BE1801E004E66FD /* HexFiend in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +130,7 @@
 				E31C294123FBE2FA00DF3442 /* Defaults */,
 				E3494C15297D175B00983648 /* Introspect */,
 				E3065AA72B81118700475AB5 /* Collections */,
+				55FABE892BE1801E004E66FD /* HexFiend */,
 			);
 			productName = "Pasteboard Viewer";
 			productReference = E3A7F1D923F7DAD400CDF428 /* Pasteboard Viewer.app */;
@@ -163,6 +166,7 @@
 				E3494C14297D175B00983648 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				9320401E2AB7D4E00080B53F /* XCRemoteSwiftPackageReference "SwiftLint" */,
 				E3065AA62B81118700475AB5 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				55FABE882BE1801E004E66FD /* XCRemoteSwiftPackageReference "HexFiend" */,
 			);
 			productRefGroup = E3A7F1DA23F7DAD400CDF428 /* Products */;
 			projectDirPath = "";
@@ -437,6 +441,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		55FABE882BE1801E004E66FD /* XCRemoteSwiftPackageReference "HexFiend" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/HexFiend/HexFiend.git";
+			requirement = {
+				branch = package;
+				kind = branch;
+			};
+		};
 		9320401E2AB7D4E00080B53F /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/SwiftLint";
@@ -472,6 +484,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		55FABE892BE1801E004E66FD /* HexFiend */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 55FABE882BE1801E004E66FD /* XCRemoteSwiftPackageReference "HexFiend" */;
+			productName = HexFiend;
+		};
 		9320401F2AB7D5030080B53F /* SwiftLintPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9320401E2AB7D4E00080B53F /* XCRemoteSwiftPackageReference "SwiftLint" */;

--- a/Pasteboard Viewer/App.swift
+++ b/Pasteboard Viewer/App.swift
@@ -12,7 +12,7 @@ struct AppMain: App {
 	@State var hostingWindow: NSWindow? // swiftlint:disable:this swiftui_state_private
 	#endif
 
-	@AppStorage("viewAsText") var viewAsText = true
+	@Default(.viewAsText) private var viewAsText
 
 	init() {
 		setUpConfig()
@@ -50,10 +50,10 @@ struct AppMain: App {
 						.keyboardShortcut("t", modifiers: [.control, .command])
 				}
 				CommandGroup(after: .toolbar) {
-					Toggle("View as Text", isOn: $viewAsText)
+					Toggle("View as Text", isOn: .init(get: { viewAsText }, set: { _ in viewAsText = true }))
 						.keyboardShortcut("1", modifiers: .command)
 
-					Toggle("View as Hex", isOn: .init(get: { !viewAsText }, set: { viewAsText = !$0 }))
+					Toggle("View as Hex", isOn: .init(get: { !viewAsText }, set: { _ in viewAsText = false }))
 						.keyboardShortcut("2", modifiers: .command)
 				}
 				#endif

--- a/Pasteboard Viewer/App.swift
+++ b/Pasteboard Viewer/App.swift
@@ -12,6 +12,8 @@ struct AppMain: App {
 	@State var hostingWindow: NSWindow? // swiftlint:disable:this swiftui_state_private
 	#endif
 
+	@AppStorage("viewAsText") var viewAsText = true
+
 	init() {
 		setUpConfig()
 
@@ -46,6 +48,13 @@ struct AppMain: App {
 				CommandGroup(after: .windowSize) {
 					Defaults.Toggle("Stay on Top", key: .stayOnTop)
 						.keyboardShortcut("t", modifiers: [.control, .command])
+				}
+				CommandGroup(after: .toolbar) {
+					Toggle("View as Text", isOn: $viewAsText)
+						.keyboardShortcut("1", modifiers: .command)
+
+					Toggle("View as Hex", isOn: .init(get: { !viewAsText }, set: { viewAsText = !$0 }))
+						.keyboardShortcut("2", modifiers: .command)
 				}
 				#endif
 				CommandGroup(replacing: .help) {

--- a/Pasteboard Viewer/Constants.swift
+++ b/Pasteboard Viewer/Constants.swift
@@ -1,4 +1,5 @@
 extension Defaults.Keys {
 	static let stayOnTop = Key<Bool>("stayInFront", default: false)
 	static let launchCount = Key<Int>("launchCount", default: 0)
+	static let viewAsText = Key<Bool>("viewAsText", default: true)
 }

--- a/Pasteboard Viewer/ContentsScreen.swift
+++ b/Pasteboard Viewer/ContentsScreen.swift
@@ -4,7 +4,7 @@ import HexFiend
 
 struct ContentsScreen: View {
 	@EnvironmentObject private var pasteboardObservable: XPasteboard.Observable
-	@State private var viewAsText = true
+	@AppStorage("viewAsText") private var viewAsText = true
 	@State private var selectedByteRanges = Set<Range<UInt64>>()
 
 	let type: Pasteboard.Type_

--- a/Pasteboard Viewer/ContentsScreen.swift
+++ b/Pasteboard Viewer/ContentsScreen.swift
@@ -25,7 +25,7 @@ struct ContentsScreen: View {
 		}
 	}
 
-	var hexBody: some View {
+	private var hexBody: some View {
 		// this uses a .number formatter instead of .byteCount,
 		// because a byte count format doesn't have a way to exclude the grouping character
 		let count = (type.data()?.count ?? 0)
@@ -60,7 +60,7 @@ struct ContentsScreen: View {
 			.extraInfo(extraInfo)
 	}
 
-	var textBody: some View {
+	private var textBody: some View {
 		let data = type.data()
 		let sizeString = (data?.count ?? 0).formatted(.byteCount(style: .file))
 		let contentType = type.utType

--- a/Pasteboard Viewer/ContentsScreen.swift
+++ b/Pasteboard Viewer/ContentsScreen.swift
@@ -7,7 +7,7 @@ import HexFiend
 
 struct ContentsScreen: View {
 	@EnvironmentObject private var pasteboardObservable: XPasteboard.Observable
-	@AppStorage("viewAsText") private var viewAsText = true
+	@Default(.viewAsText) private var viewAsText
 	@State private var selectedByteRanges = Set<Range<UInt64>>()
 
 	let type: Pasteboard.Type_

--- a/Pasteboard Viewer/MainScreen.swift
+++ b/Pasteboard Viewer/MainScreen.swift
@@ -63,6 +63,8 @@ struct MainScreen: View {
 		Group {
 			if let selectedType {
 				ContentsScreen(type: selectedType)
+					.id(selectedType.id)
+					.id(pasteboardObservable.info?.id)
 					.environmentObject(pasteboardObservable)
 			} else {
 				#if os(macOS)


### PR DESCRIPTION
This adds a hex viewer to Pasteboard Viewer and fixes #24.

This uses the [HexFiend framework](https://github.com/hexfiend/hexfiend) to add a hex viewer to the app, which can be accessed by toggling a picker in the toolbar.

Some things to note:

- This depends on the `package` branch of the HexFiend project, as that is the branch that adds a Package.swift file. It is technically unreleased, although it appears to be fully functional.
- The format of the "extra info" in the toolbar is meant to mimic the format shown in the Hex Fiend app as closely as possible.
- Selection is not preserved when toggling between text and hex modes.

<img width="989" alt="Screenshot 2024-05-02 at 9 10 09 PM" src="https://github.com/sindresorhus/Pasteboard-Viewer/assets/112699/d9f4eb42-4f0f-4e60-bc54-96ffb3b25199">
<img width="989" alt="Screenshot 2024-05-02 at 9 10 21 PM" src="https://github.com/sindresorhus/Pasteboard-Viewer/assets/112699/97625980-7d57-4a55-9f69-71a83a17f291">
